### PR TITLE
fix: load module plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     rules: {
         'no-console': 'off',
         'spaced-comment': ["error", "always", { "markers": ["/"] }],
-        '@typescript-eslint/prefer-for-of': 'off'
+        '@typescript-eslint/prefer-for-of': 'off',
+        '@typescript-eslint/no-require-imports': 'off'
     },
 };

--- a/packages/app-autoload/src/index.ts
+++ b/packages/app-autoload/src/index.ts
@@ -70,7 +70,7 @@ async function load(appConfig: AppConfig, childInstance: FastifyInstance) {
 
     // load module plugins
     if (appConfig.pluginConfig) {
-        for await (const [name, config] of Object.entries(appConfig.pluginConfig)) {
+        for (const [name, config] of Object.entries(appConfig.pluginConfig)) {
             if (name === '@hoth/app-autoload') {
                 if (config.prefix) {
                     appConfig.prefix = config.prefix;
@@ -78,9 +78,10 @@ async function load(appConfig: AppConfig, childInstance: FastifyInstance) {
                 continue;
             }
             let mod: any = resolveFrom.silent(appConfig.dir, name);
-            mod = mod.__esModule ? mod.default : mod;
             if (mod) {
-                await childInstance.register(mod, config);
+                mod = require(mod);
+                mod = mod.__esModule ? mod.default : mod;
+                childInstance.register(mod, config);
             }
         }
     }


### PR DESCRIPTION
1. resolveFrom.silent 返回的是一个字符串路径。
2. fastify 的 register 会保证按顺序逐个执行。